### PR TITLE
Fix crashes under load when using TLS

### DIFF
--- a/mod_websocket.c
+++ b/mod_websocket.c
@@ -960,7 +960,9 @@ static void mod_websocket_data_framing(const WebSocketServer *server,
 
             /* Check to see if there is any data to write. */
             do {
-                rv = apr_queue_trypop(state->queue, &msg);
+                void *el;
+                rv = apr_queue_trypop(state->queue, &el);
+                msg = el;
             } while (APR_STATUS_IS_EINTR(rv));
 
             if (rv == APR_SUCCESS) {


### PR DESCRIPTION
Occasionally, when under load from several `wss://` connections, Apache will segfault. This appears to be due to mod_websocket's multithreaded use of the bucket brigade pair; note that OpenSSL may read during a write and vice-versa, which could cause multiple threads to access the same brigade simultaneously. The problem seems to be easier to reproduce on Windows (I haven't reproduced with a Linux server yet).

This pull request implements single-threaded access to the bucket brigade, with cross-thread communication being done through a queue. The entire backstory and discussion can be read on the [httpd modules-dev mailing list](http://mail-archives.apache.org/mod_mbox/httpd-modules-dev/201502.mbox/%3C54ED1473.1060604%40ni.com%3E).
